### PR TITLE
Update 04.vgg16_bn_cifar10.ipynb

### DIFF
--- a/tutorials/04.vgg16_bn_cifar10.ipynb
+++ b/tutorials/04.vgg16_bn_cifar10.ipynb
@@ -147,7 +147,7 @@
     "    lmbda=5e-4,\n",
     "    weight_decay=5e-4, \n",
     "    weight_decay_type='l1_norm', \n",
-    "    start_pruning_steps=50 * len(trainloader), # start pruning after 10 epochs. Start pruning at initialization stage.\n",
+    "    start_pruning_steps=50 * len(trainloader), # start pruning after 50 epochs. Start pruning at initialization stage.\n",
     "    epsilon=0.9)"
    ]
   },


### PR DESCRIPTION
One wrong description on start_pruning_steps setting, where the setting seems starts pruning after 50 epochs, but described as after 10 epochs as follow: 
start_pruning_steps=50 * len(trainloader), # start pruning after 10 epochs. Start pruning at initialization stage.