### PR TITLE
Add cuda device flexibility

### DIFF
--- a/only_train_once/__init__.py
+++ b/only_train_once/__init__.py
@@ -45,7 +45,7 @@ class OTO:
 
     def hesso(self, lr=0.1, weight_decay=None, first_momentum=None, second_momentum=None, \
                variant='sgd', target_group_sparsity=0.5, start_pruning_step=0, \
-               pruning_steps=1, pruning_periods=1, \
+               pruning_steps=1, pruning_periods=1, device='cuda',\
                dampening=None, group_divisible=1, fixed_zero_groups=True, importance_score_criteria='default'):
         from .optimizer import HESSO
         self._optimizer = HESSO(
@@ -61,7 +61,8 @@ class OTO:
             pruning_periods=pruning_periods,
             pruning_steps=pruning_steps,
             group_divisible=group_divisible,
-            importance_score_criteria=importance_score_criteria
+            importance_score_criteria=importance_score_criteria, 
+            device=device
         )
         return self._optimizer
 

--- a/only_train_once/optimizer/hesso.py
+++ b/only_train_once/optimizer/hesso.py
@@ -12,7 +12,7 @@ class HESSO(Optimizer):
     HESSO: Hybrid Efficient Structured Sparse Optimizer
     '''
     def __init__(self, params, variant='sgd', lr=required, first_momentum=None, second_momentum=None, \
-                 dampening=None, weight_decay=None, target_group_sparsity=0.5, \
+                 dampening=None, weight_decay=None, target_group_sparsity=0.5,  device='cuda',\
                  tolerance_group_sparsity=0.05, start_pruning_step=0, pruning_steps=None, pruning_periods=1, \
                  group_divisible=1, fixed_zero_groups=True, importance_score_criteria='default'):
 
@@ -28,6 +28,7 @@ class HESSO(Optimizer):
         self.pruning_steps = pruning_steps
         self.pruning_period_duration = self.pruning_steps // self.pruning_periods # How many pruning steps for each period
         self.curr_pruning_period = 0 # Track pruning period
+        self.device=device
 
         # Set up hyper-parameters related to baseline optimizer
         first_momentum = first_momentum if first_momentum is not None else DEFAULT_OPT_PARAMS[variant]['first_momentum']
@@ -232,7 +233,7 @@ class HESSO(Optimizer):
                         self.target_num_redundant_groups += (refined_num_active_redundant_groups - len(self.active_redundant_idxes[group['id']]))
                         self.active_redundant_idxes[group['id']] = self.active_redundant_idxes[group['id']][:refined_num_active_redundant_groups]
                 self.important_idxes[group['id']] = [i for i in self.important_idxes[group['id']] if (i not in self.active_redundant_idxes[group['id']] and i not in self.pruned_idxes[group['id']])]
-                group['active_redundant_bool'] = torch.zeros(group['num_groups'], dtype=torch.bool).cuda()
+                group['active_redundant_bool'] = torch.zeros(group['num_groups'], dtype=torch.bool).cuda(device=self.device)
                 group['active_redundant_bool'][self.active_redundant_idxes[group['id']]] = True
         return
 


### PR DESCRIPTION
I wanted to use OTO over a few cuda devices, which gave errors whenever using any cuda but the default 'cuda:0'.
The reason was this tensor in `hesso.py`
> group['active_redundant_bool'] = torch.zeros(group['num_groups'], dtype=torch.bool).cuda()

This is simply solved by adding a `device` parameter to the `HESSO` class and sending the above tensor to the correct device. It also required updating `__init.py` to initialize HESSO correctly. 

I was able to use OTO on my model across multiple cuda devices.